### PR TITLE
Fix for COOLCONF functions

### DIFF
--- a/Trinamic_TMC2130/Trinamic_TMC2130.cpp
+++ b/Trinamic_TMC2130/Trinamic_TMC2130.cpp
@@ -724,56 +724,56 @@ uint8_t Trinamic_TMC2130::alter_COOLCONF(uint32_t data, uint32_t mask)
 uint8_t Trinamic_TMC2130::set_COOLCONF(uint8_t position, uint8_t value)
 {
 
-  alter_COOLCONF( uint32_t(value)<<position, TMC_CHOPCONF_MASKS[position]<<position);
+  alter_COOLCONF( uint32_t(value)<<position, TMC_COOLCONF_MASKS[position]<<position);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_sfilt(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SFILT, value);
+  set_COOLCONF(TMC_COOLCONF_SFILT, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_sgt(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SGT, value);
+  set_COOLCONF(TMC_COOLCONF_SGT, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_seimin(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SEIMIN, value);
+  set_COOLCONF(TMC_COOLCONF_SEIMIN, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_sedn(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SEDN, value);
+  set_COOLCONF(TMC_COOLCONF_SEDN, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_semax(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SEMAX, value);
+  set_COOLCONF(TMC_COOLCONF_SEMAX, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_seup(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SEUP, value);
+  set_COOLCONF(TMC_COOLCONF_SEUP, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_semin(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SEMIN, value);
+  set_COOLCONF(TMC_COOLCONF_SEMIN, value);
 
   return _status;
 }

--- a/Trinamic_TMC2130/Trinamic_TMC2130.cpp
+++ b/Trinamic_TMC2130/Trinamic_TMC2130.cpp
@@ -606,6 +606,10 @@ uint8_t Trinamic_TMC2130::set_mres(uint16_t value)
     case 128:
       data = 1;
     break;
+	case 256:
+  default:
+		data = 0;
+		break;
   }
 
   set_CHOPCONF(TMC_CHOPCONF_MRES, data);

--- a/Trinamic_TMC2130/Trinamic_TMC2130.cpp
+++ b/Trinamic_TMC2130/Trinamic_TMC2130.cpp
@@ -606,10 +606,6 @@ uint8_t Trinamic_TMC2130::set_mres(uint16_t value)
     case 128:
       data = 1;
     break;
-	case 256:
-  default:
-		data = 0;
-		break;
   }
 
   set_CHOPCONF(TMC_CHOPCONF_MRES, data);
@@ -728,56 +724,56 @@ uint8_t Trinamic_TMC2130::alter_COOLCONF(uint32_t data, uint32_t mask)
 uint8_t Trinamic_TMC2130::set_COOLCONF(uint8_t position, uint8_t value)
 {
 
-  alter_COOLCONF( uint32_t(value)<<position, TMC_COOLCONF_MASKS[position]<<position);
+  alter_COOLCONF( uint32_t(value)<<position, TMC_CHOPCONF_MASKS[position]<<position);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_sfilt(uint8_t value)
 {
-  set_COOLCONF(TMC_COOLCONF_SFILT, value);
+  set_CHOPCONF(TMC_COOLCONF_SFILT, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_sgt(uint8_t value)
 {
-  set_COOLCONF(TMC_COOLCONF_SGT, value);
+  set_CHOPCONF(TMC_COOLCONF_SGT, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_seimin(uint8_t value)
 {
-  set_COOLCONF(TMC_COOLCONF_SEIMIN, value);
+  set_CHOPCONF(TMC_COOLCONF_SEIMIN, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_sedn(uint8_t value)
 {
-  set_COOLCONF(TMC_COOLCONF_SEDN, value);
+  set_CHOPCONF(TMC_COOLCONF_SEDN, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_semax(uint8_t value)
 {
-  set_COOLCONF(TMC_COOLCONF_SEMAX, value);
+  set_CHOPCONF(TMC_COOLCONF_SEMAX, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_seup(uint8_t value)
 {
-  set_COOLCONF(TMC_COOLCONF_SEUP, value);
+  set_CHOPCONF(TMC_COOLCONF_SEUP, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_semin(uint8_t value)
 {
-  set_COOLCONF(TMC_COOLCONF_SEMIN, value);
+  set_CHOPCONF(TMC_COOLCONF_SEMIN, value);
 
   return _status;
 }

--- a/Trinamic_TMC2130/Trinamic_TMC2130.cpp
+++ b/Trinamic_TMC2130/Trinamic_TMC2130.cpp
@@ -606,6 +606,10 @@ uint8_t Trinamic_TMC2130::set_mres(uint16_t value)
     case 128:
       data = 1;
     break;
+	case 256:
+  default:
+		data = 0;
+		break;
   }
 
   set_CHOPCONF(TMC_CHOPCONF_MRES, data);
@@ -724,56 +728,56 @@ uint8_t Trinamic_TMC2130::alter_COOLCONF(uint32_t data, uint32_t mask)
 uint8_t Trinamic_TMC2130::set_COOLCONF(uint8_t position, uint8_t value)
 {
 
-  alter_COOLCONF( uint32_t(value)<<position, TMC_CHOPCONF_MASKS[position]<<position);
+  alter_COOLCONF( uint32_t(value)<<position, TMC_COOLCONF_MASKS[position]<<position);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_sfilt(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SFILT, value);
+  set_COOLCONF(TMC_COOLCONF_SFILT, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_sgt(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SGT, value);
+  set_COOLCONF(TMC_COOLCONF_SGT, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_seimin(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SEIMIN, value);
+  set_COOLCONF(TMC_COOLCONF_SEIMIN, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_sedn(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SEDN, value);
+  set_COOLCONF(TMC_COOLCONF_SEDN, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_semax(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SEMAX, value);
+  set_COOLCONF(TMC_COOLCONF_SEMAX, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_seup(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SEUP, value);
+  set_COOLCONF(TMC_COOLCONF_SEUP, value);
 
   return _status;
 }
 
 uint8_t Trinamic_TMC2130::set_semin(uint8_t value)
 {
-  set_CHOPCONF(TMC_COOLCONF_SEMIN, value);
+  set_COOLCONF(TMC_COOLCONF_SEMIN, value);
 
   return _status;
 }


### PR DESCRIPTION
Sorry about the messed up pull request just earlier...

This just corrects the COOLCONF functions to alter the COOLCONF registers instead of the CHOPCONF registers.

It also adds a case for 256, and a default for the MRES switch... Probably not really necessary, but just for completeness!